### PR TITLE
Use object shorthand for properties

### DIFF
--- a/index.js
+++ b/index.js
@@ -77,9 +77,9 @@ proto.preprocess = function (dep) {
         .replace(/^"|"$/g, '')
       var target = this.depIndex[dep.deps[path]]
       imports.push({
-        name: name,
-        path: path,
-        target: target,
+        name,
+        path,
+        target,
         maps: toMapping(maps),
         index: i
       })
@@ -101,9 +101,9 @@ proto.preprocess = function (dep) {
   }
 
   dep.parsed = {
-    tokens: tokens,
-    imports: imports,
-    exports: exports
+    tokens,
+    imports,
+    exports
   }
 }
 


### PR DESCRIPTION
This rule is on its way into the latest Standard ☺️

ref: https://github.com/standard/eslint-config-standard/pull/166

Compatibility: This works in Node.js >=4 which is the same version that introduced support for `Object.keys` which is already being used in the codebase ✅ 